### PR TITLE
fix/only_copy_pngs_over_during_update_baseline

### DIFF
--- a/src/updateBaselineShots.js
+++ b/src/updateBaselineShots.js
@@ -17,10 +17,13 @@ export default (fs, config) =>
     );
 
     for (let i = 0; i < latestSnaps.length; i++) {
-      const src = path.resolve(dirPath, latestSnaps[i]);
-      const destination = path.resolve(config.baseline, latestSnaps[i]);
+      const isPng = latestSnaps[i].split('.').pop() === 'png';
+      if (isPng) {
+        const src = path.resolve(dirPath, latestSnaps[i]);
+        const destination = path.resolve(config.baseline, latestSnaps[i]);
 
-      fs.copyFileSync(src, destination);
+        fs.copyFileSync(src, destination);
+      }
     }
 
     logger.info('update-baseline-shots', 'Baseline directory updated');

--- a/src/updateBaselineShots.test.js
+++ b/src/updateBaselineShots.test.js
@@ -7,14 +7,22 @@ describe('update baseline shots', () => {
 
   beforeEach(() => {
     mockFs = {
-      readdirSync: () => ['1', '2', '3', '4', '5', '6'],
+      readdirSync: () => [
+        '1.png',
+        '2.png',
+        '3.png',
+        '4.png',
+        '5.png',
+        '6.png',
+        '7.txt'
+      ],
       access: () => {},
       mkdirSync: () => {},
       copyFileSync: jest.fn()
     };
   });
 
-  it('copies src files to destination for all files', async () => {
+  it('copies src png files to destination for all files', async () => {
     const config = {
       baseline: 'baseline',
       latest: 'latest'


### PR DESCRIPTION
Only copy over PNG files when updating the baseline.
Fixes issue: https://github.com/newsuk/AyeSpy/issues/28