### PR TITLE
chore: fix remoteActions upload test

### DIFF
--- a/src/remoteActions.js
+++ b/src/remoteActions.js
@@ -181,13 +181,9 @@ const uploadRemoteKeys = async (key, config) => {
         ContentType: contentType
       };
 
-      const putObjectPromise = s3.putObject(uploadParams).promise();
-
-      const promises = [];
-      promises.push(putObjectPromise);
-      return Promise.all(promises);
+      return s3.putObject(uploadParams).promise();
     })
-  );
+  ).catch(err => logger.error('remote-actions', err));
 };
 
 export {

--- a/src/remoteActions.test.js
+++ b/src/remoteActions.test.js
@@ -90,9 +90,9 @@ describe('Remote interactions', () => {
 
     await uploadRemoteKeys(key, config)
       .then(promises => promises[0])
-      .then(data => data.map(obj => obj.Key))
+      .then(obj => obj.Key)
       .then(name => {
-        expect(name).toEqual(['chrome/baseline/mock/resolved/path/file1']);
+        expect(name).toEqual('chrome/baseline/mock/resolved/path/file1');
       });
   });
 });


### PR DESCRIPTION
Remove unnecessary array of promises in uploadRemoteKeys
and catch error
and fix test