### PR TITLE
fix: correcting the repo URLS in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "bin": {
     "ayespy": "lib/bin/run.js"
   },
-  "repository": "git+https://github.com/L0wry/Aye-Spy.git",
+  "repository": "git+https://github.com/newsuk/AyeSpy",
   "keywords": [
     "visual-regression",
     "testing",
@@ -36,9 +36,9 @@
   "author": "newsuk",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/newsuk/Aye-Spy/issues"
+    "url": "https://github.com/newsuk/AyeSpy/issues"
   },
-  "homepage": "https://github.com/newsuk/Aye-Spy#readme",
+  "homepage": "https://github.com/newsuk/AyeSpy#readme",
   "dependencies": {
     "aws-sdk": "^2.252.1",
     "commander": "^2.15.1",


### PR DESCRIPTION
Small corrections to `package.json` to resolve issues with commands such as `npm repo aye-spy` which currently take you to an incorrect git hub repo.