### PR TITLE
feat: on before suite script

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ async function clickElement (browser, By) {
 module.exports = clickElement;
 ```
 
+## on Before Suite Script
+
+In cases where you need to run a script once, before the entire suite is launched (e.g. setting up global objects or setting up external services), pass the path of the script into `onBeforeSuiteScript` in the config file.
+
+Unlike the onReady and onBefore script options onBeforeSuite scripts do not have any driver exposed and take no arguments. Any external dependancys will need to be set up independantly inside the script.
+
 ## Mobile Emulator
 
 For scenarios where you need to use a mobile emulator, pass in the device name to the property `mobileDeviceName` on your config. Note that at the moment, this will only work with the chrome browser.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ module.exports = clickElement;
 
 In cases where you need to run a script once, before the entire suite is launched (e.g. setting up global objects or setting up external services), pass the path of the script into `onBeforeSuiteScript` in the config file.
 
-Unlike the onReady and onBefore script options onBeforeSuite scripts do not have any driver exposed and take no arguments. Any external dependancys will need to be set up independantly inside the script.
+Unlike the onReady and onBefore script options, onBeforeSuite script does not have a driver passed to it as an argument. Any external dependencies will need to be set up independantly inside the script.
 
 ## Mobile Emulator
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Example config to run Aye Spy:
         ],
         "waitForElement": "#section-news", // explicitly wait for a selector to be visible before snap
         "onReadyScript": "./scripts/clickSelector.js", // run a script before snap
+        "onBeforeSuiteScript": "./scripts/login.js" // run a script before the entire suite (this script takes no parameters)
         "wait": 2000 // implicitly wait before taking a snap
       }
     ]

--- a/e2eTests/generic/onBeforeSuiteScript/onBeforeSuiteScript.test.js
+++ b/e2eTests/generic/onBeforeSuiteScript/onBeforeSuiteScript.test.js
@@ -33,8 +33,6 @@ describe('e2e Tests running onBeforeSuiteScript', () => {
 
     expect(stdout).toEqual(expect.stringContaining('Script has Run!'));
     expect(exitCode).toEqual(0);
-    const latestDirFiles = fs.readdirSync(dirPath);
-    expect(latestDirFiles).toEqual(['image-large.png']);
   });
 
 });

--- a/e2eTests/generic/onBeforeSuiteScript/onBeforeSuiteScriptConfig.json
+++ b/e2eTests/generic/onBeforeSuiteScript/onBeforeSuiteScriptConfig.json
@@ -1,0 +1,16 @@
+{
+  "gridUrl": "http://hub:4444/wd/hub",
+  "baseline": "./e2eTests/generic/onBeforeSuiteScript/baseline",
+  "latest": "./e2eTests/generic/onBeforeSuiteScript/latest",
+  "generatedDiffs": "./e2eTests/generic/onBeforeSuiteScript/generatedDiffs",
+  "report": "./e2eTests/generic/onBeforeSuiteScript/reports",
+  "remoteBucketName": "aye-spy",
+  "remoteRegion": "eu-west-1",
+  "onBeforeSuiteScript": "./e2eTests/generic/onBeforeSuiteScript/script.js",
+  "scenarios": [
+    {
+      "url": "http://ayespy_report:4000",
+      "label": "image",
+      "viewports": [{"height": 2400, "width": 1024, "label": "large"}]
+    }]
+}

--- a/e2eTests/generic/onBeforeSuiteScript/script.js
+++ b/e2eTests/generic/onBeforeSuiteScript/script.js
@@ -1,0 +1,8 @@
+
+function thing() {
+  return new Promise((resolve, reject) => {
+    resolve(console.log('Script has Run!'))
+  })
+}
+
+module.exports = thing

--- a/e2eTests/generic/onBeforeSuiteScript/snapLocal.test.js
+++ b/e2eTests/generic/onBeforeSuiteScript/snapLocal.test.js
@@ -1,0 +1,40 @@
+/* globals expect */
+
+import path from 'path';
+import fs from 'fs';
+import { execSync } from 'child_process';
+import config from './onBeforeSuiteScriptConfig';
+
+describe('e2e Tests running onBeforeSuiteScript', () => {
+  let dirPath;
+
+  beforeEach(() => {
+    dirPath = path.resolve(config.latest);
+
+    if (fs.existsSync(dirPath)) {
+      const files = fs.readdirSync(dirPath);
+      files.forEach(file => fs.unlinkSync(`${dirPath}/${file}`));
+      fs.rmdirSync(dirPath);
+    }
+  });
+
+  it('should successfully run the script before taking a snapshot', async () => {
+    let exitCode = 0;
+    let stdout;
+    try {
+      stdout = execSync(
+        'node ./lib/bin/run.js snap --browser chrome --config e2eTests/generic/onBeforeSuiteScript/onBeforeSuiteScriptConfig.json'
+      ).toString();
+      //pipe stdout to Jest console
+      console.log(stdout);
+    } catch (error) {
+      exitCode = error.status;
+    }
+
+    expect(stdout).toEqual(expect.stringContaining('Script has Run!'));
+    expect(exitCode).toEqual(0);
+    const latestDirFiles = fs.readdirSync(dirPath);
+    expect(latestDirFiles).toEqual(['image-large.png']);
+  });
+
+});

--- a/src/__mocks__/failingOnBeforeSuiteMock.js
+++ b/src/__mocks__/failingOnBeforeSuiteMock.js
@@ -1,0 +1,3 @@
+module.exports = function onBeforeSuiteMock() {
+  throw new Error('Boom!');
+};

--- a/src/__mocks__/onBeforeSuiteMock.js
+++ b/src/__mocks__/onBeforeSuiteMock.js
@@ -1,0 +1,4 @@
+/* globals jest */
+module.exports = function onBeforeSuiteMock(...params) {
+  return jest.fn(params);
+};

--- a/src/executeScript.js
+++ b/src/executeScript.js
@@ -1,7 +1,14 @@
 import path from 'path';
 import { By } from 'selenium-webdriver';
 
-export default async function executeScript(driver, script) {
-  const scriptToExecute = require(path.resolve(script)); // eslint-disable-line
+const loadFile = (script) => require(path.resolve(script)); // eslint-disable-line
+
+export async function executeScript(script) {
+  const scriptToExecute = loadFile(script);
+  return scriptToExecute();
+}
+
+export async function executeScriptWithDriver(driver, script) {
+  const scriptToExecute = loadFile(script);
   return scriptToExecute(driver, By);
 }

--- a/src/executeScript.js
+++ b/src/executeScript.js
@@ -1,8 +1,12 @@
 import path from 'path';
 import { By } from 'selenium-webdriver';
+import fs from 'fs';
 
-const loadFile = (script) => require(path.resolve(script)); // eslint-disable-line
-
+const loadFile = script => {
+  if (!fs.existsSync(script))
+    throw new Error(`Error: Could not find the file: ${script}`);
+  return require(path.resolve(script)); // eslint-disable-line
+};
 export function executeScript(script) {
   return new Promise(async (resolve, reject) => {
     try {
@@ -16,6 +20,13 @@ export function executeScript(script) {
 }
 
 export function executeScriptWithDriver(driver, script) {
-  const scriptToExecute = loadFile(script);
-  return scriptToExecute(driver, By);
+  return new Promise(async (resolve, reject) => {
+    try {
+      const scriptToExecute = loadFile(script);
+      await scriptToExecute(driver, By);
+      resolve();
+    } catch (error) {
+      reject(error);
+    }
+  });
 }

--- a/src/executeScript.js
+++ b/src/executeScript.js
@@ -3,9 +3,16 @@ import { By } from 'selenium-webdriver';
 
 const loadFile = (script) => require(path.resolve(script)); // eslint-disable-line
 
-export async function executeScript(script) {
-  const scriptToExecute = loadFile(script);
-  return scriptToExecute();
+export function executeScript(script) {
+  return new Promise(async (resolve, reject) => {
+    try {
+      const scriptToExecute = loadFile(script);
+      await scriptToExecute();
+      resolve();
+    } catch (error) {
+      reject(error);
+    }
+  });
 }
 
 export async function executeScriptWithDriver(driver, script) {

--- a/src/executeScript.js
+++ b/src/executeScript.js
@@ -1,0 +1,7 @@
+import path from 'path';
+import { By } from 'selenium-webdriver';
+
+export default async function executeScript(driver, script) {
+  const scriptToExecute = require(path.resolve(script)); // eslint-disable-line
+  return scriptToExecute(driver, By);
+}

--- a/src/executeScript.js
+++ b/src/executeScript.js
@@ -7,23 +7,20 @@ const loadFile = script => {
     throw new Error(`Error: Could not find the file: ${script}`);
   return require(path.resolve(script)); // eslint-disable-line
 };
+
 export function executeScript(script) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const scriptToExecute = loadFile(script);
-      await scriptToExecute();
-      resolve();
-    } catch (error) {
-      reject(error);
-    }
-  });
+  return execute(script);
 }
 
 export function executeScriptWithDriver(driver, script) {
+  return execute(script, driver, By);
+}
+
+function execute(script, ...params) {
   return new Promise(async (resolve, reject) => {
     try {
       const scriptToExecute = loadFile(script);
-      await scriptToExecute(driver, By);
+      await scriptToExecute(...params);
       resolve();
     } catch (error) {
       reject(error);

--- a/src/executeScript.js
+++ b/src/executeScript.js
@@ -15,7 +15,7 @@ export function executeScript(script) {
   });
 }
 
-export async function executeScriptWithDriver(driver, script) {
+export function executeScriptWithDriver(driver, script) {
   const scriptToExecute = loadFile(script);
   return scriptToExecute(driver, By);
 }

--- a/src/executeScript.test.js
+++ b/src/executeScript.test.js
@@ -1,0 +1,20 @@
+/* globals jest expect */
+import executeScript from './executeScript';
+
+jest.mock('require');
+
+describe('executeScript', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should execute a custom script', async () => {
+    const pathToScript = '../__mocks__/onReadyScriptMock.js';
+    const driverStub = {};
+    const scriptStub = jest.fn();
+    require.mockImplementation(() => scriptStub);
+
+    await executeScript(driverStub, pathToScript);
+    expect(scriptStub).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/executeScript.test.js
+++ b/src/executeScript.test.js
@@ -1,5 +1,5 @@
 /* globals jest expect */
-import { executeScriptWithDriver } from './executeScript';
+import { executeScriptWithDriver, executeScript } from './executeScript';
 import onBeforeSuiteMock from './__mocks__/onBeforeSuiteMock.js';
 import { By } from './__mocks__/selenium-webdriver';
 
@@ -18,5 +18,13 @@ describe('executeScript', () => {
 
     expect(onBeforeSuiteMock).toHaveBeenCalledTimes(1);
     expect(onBeforeSuiteMock).toHaveBeenCalledWith(driverStub, By);
+  });
+
+  it('should execute a custom script without a driver', () => {
+    const pathToScript = './src/__mocks__/onBeforeSuiteMock.js';
+
+    executeScript(pathToScript);
+
+    expect(onBeforeSuiteMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/executeScript.test.js
+++ b/src/executeScript.test.js
@@ -1,5 +1,5 @@
 /* globals jest expect */
-import executeScript from './executeScript';
+import { executeScriptWithDriver } from './executeScript';
 import onBeforeSuiteMock from './__mocks__/onBeforeSuiteMock.js';
 import { By } from './__mocks__/selenium-webdriver';
 
@@ -10,11 +10,11 @@ describe('executeScript', () => {
     jest.clearAllMocks();
   });
 
-  it('should execute a custom script', () => {
+  it('should execute a custom script with a driver', () => {
     const pathToScript = './src/__mocks__/onBeforeSuiteMock.js';
     const driverStub = {};
 
-    executeScript(driverStub, pathToScript);
+    executeScriptWithDriver(driverStub, pathToScript);
 
     expect(onBeforeSuiteMock).toHaveBeenCalledTimes(1);
     expect(onBeforeSuiteMock).toHaveBeenCalledWith(driverStub, By);

--- a/src/executeScript.test.js
+++ b/src/executeScript.test.js
@@ -10,21 +10,62 @@ describe('executeScript', () => {
     jest.clearAllMocks();
   });
 
-  it('should execute a custom script with a driver', () => {
-    const pathToScript = './src/__mocks__/onBeforeSuiteMock.js';
-    const driverStub = {};
+  describe('withDriver', () => {
+    let pathToScript;
+    let driverStub;
 
-    executeScriptWithDriver(driverStub, pathToScript);
+    beforeEach(() => {
+      pathToScript = './src/__mocks__/onBeforeSuiteMock.js';
+      driverStub = {};
+    });
 
-    expect(onBeforeSuiteMock).toHaveBeenCalledTimes(1);
-    expect(onBeforeSuiteMock).toHaveBeenCalledWith(driverStub, By);
+    it('should execute a custom script', async () => {
+      await executeScriptWithDriver(driverStub, pathToScript);
+
+      expect(onBeforeSuiteMock).toHaveBeenCalledTimes(1);
+      expect(onBeforeSuiteMock).toHaveBeenCalledWith(driverStub, By);
+    });
+
+    it('should throw an error if the given script does not exist', () => {
+      pathToScript = './nonExistantScript.js';
+
+      return expect(
+        executeScriptWithDriver(driverStub, pathToScript)
+      ).rejects.toThrow(
+        'Error: Could not find the file: ./nonExistantScript.js'
+      );
+    });
+
+    it('should throw an error if the script fails', () => {
+      pathToScript = './src/__mocks__/failingOnBeforeSuiteMock.js';
+
+      return expect(
+        executeScriptWithDriver(driverStub, pathToScript)
+      ).rejects.toThrow('Boom!');
+    });
   });
 
-  it('should execute a custom script without a driver', () => {
-    const pathToScript = './src/__mocks__/onBeforeSuiteMock.js';
+  describe('withoutDriver', () => {
+    let pathToScript = './src/__mocks__/onBeforeSuiteMock.js';
 
-    executeScript(pathToScript);
+    it('should execute a custom script', () => {
+      executeScript(pathToScript);
 
-    expect(onBeforeSuiteMock).toHaveBeenCalledTimes(1);
+      return expect(onBeforeSuiteMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw an error if the given script does not exist', () => {
+      pathToScript = './nonExistantScript.js';
+
+      return expect(executeScript(pathToScript)).rejects.toThrow(
+        'Error: Could not find the file: ./nonExistantScript.js'
+      );
+    });
+
+    it('should throw an error if the given script fails', () => {
+      pathToScript = './src/__mocks__/failingOnBeforeSuiteMock.js';
+
+      return expect(executeScript(pathToScript)).rejects.toThrow('Boom!');
+    });
   });
 });

--- a/src/executeScript.test.js
+++ b/src/executeScript.test.js
@@ -1,20 +1,22 @@
 /* globals jest expect */
 import executeScript from './executeScript';
+import onBeforeSuiteMock from './__mocks__/onBeforeSuiteMock.js';
+import { By } from './__mocks__/selenium-webdriver';
 
-jest.mock('require');
+jest.mock('onBeforeSuiteMock');
 
 describe('executeScript', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should execute a custom script', async () => {
-    const pathToScript = '../__mocks__/onReadyScriptMock.js';
+  it('should execute a custom script', () => {
+    const pathToScript = './src/__mocks__/onBeforeSuiteMock.js';
     const driverStub = {};
-    const scriptStub = jest.fn();
-    require.mockImplementation(() => scriptStub);
 
-    await executeScript(driverStub, pathToScript);
-    expect(scriptStub).toHaveBeenCalledTimes(1);
+    executeScript(driverStub, pathToScript);
+
+    expect(onBeforeSuiteMock).toHaveBeenCalledTimes(1);
+    expect(onBeforeSuiteMock).toHaveBeenCalledWith(driverStub, By);
   });
 });

--- a/src/getScreenshots.js
+++ b/src/getScreenshots.js
@@ -5,8 +5,10 @@ import ProgressBar from './progressBar';
 const onComplete = () => ProgressBar.tick();
 const onError = () => ProgressBar.stop();
 
-const generateSnapShotPromises = (SnapShotter, config) =>
-  config.scenarios.reduce((accum, scenario) => {
+const generateSnapShotPromises = (SnapShotter, config) => {
+  //config.onBeforeSuiteScript();
+
+  return config.scenarios.reduce((accum, scenario) => {
     scenarioValidator(scenario);
 
     scenario.viewports.forEach(viewport => {
@@ -39,6 +41,7 @@ const generateSnapShotPromises = (SnapShotter, config) =>
     });
     return accum;
   }, []);
+};
 
 async function getScreenshots(SnapShotter, config) {
   return new Promise(async resolve => {

--- a/src/getScreenshots.js
+++ b/src/getScreenshots.js
@@ -1,12 +1,13 @@
 import webdriver, { By, until } from 'selenium-webdriver';
 import scenarioValidator from './scenarioValidator';
 import ProgressBar from './progressBar';
+import { executeScript } from './executeScript';
 
 const onComplete = () => ProgressBar.tick();
 const onError = () => ProgressBar.stop();
 
 const generateSnapShotPromises = (SnapShotter, config) => {
-  //config.onBeforeSuiteScript();
+  if (config.onBeforeSuiteScript) executeScript(config.onBeforeSuiteScript);
 
   return config.scenarios.reduce((accum, scenario) => {
     scenarioValidator(scenario);

--- a/src/getScreenshots.js
+++ b/src/getScreenshots.js
@@ -43,20 +43,19 @@ const generateSnapShotPromises = (SnapShotter, config) => {
   }, []);
 };
 
-async function executeOnBeforeSuiteScript(scriptPath) {
-  if (scriptPath) {
-    await executeScript(scriptPath).catch(error => {
-      logger.error(
-        'getSnappshots',
-        `❌  Unable to run onBeforeSuite script:\n  due to: ${error}`
-      );
-    });
-  }
+function executeOnBeforeSuiteScript(scriptPath) {
+  executeScript(scriptPath).catch(error => {
+    logger.error(
+      'getScreenshots',
+      `❌  Unable to run onBeforeSuite script:\n  due to: ${error}`
+    );
+  });
 }
 
 async function getScreenshots(SnapShotter, config) {
   return new Promise(async resolve => {
-    await executeOnBeforeSuiteScript(config.onBeforeSuiteScript);
+    if (config.onBeforeSuiteScript)
+      await executeOnBeforeSuiteScript(config.onBeforeSuiteScript);
 
     const promises = generateSnapShotPromises(SnapShotter, config);
 

--- a/src/getScreenshots.js
+++ b/src/getScreenshots.js
@@ -1,7 +1,6 @@
 import webdriver, { By, until } from 'selenium-webdriver';
 import scenarioValidator from './scenarioValidator';
 import ProgressBar from './progressBar';
-import logger from './logger';
 import { executeScript } from './executeScript';
 
 const onComplete = () => ProgressBar.tick();
@@ -44,18 +43,23 @@ const generateSnapShotPromises = (SnapShotter, config) => {
 };
 
 function executeOnBeforeSuiteScript(scriptPath) {
-  executeScript(scriptPath).catch(error => {
-    logger.error(
-      'getScreenshots',
+  return executeScript(scriptPath).catch(error => {
+    throw new Error(
       `❌  Unable to run onBeforeSuite script:\n  due to: ${error}`
     );
   });
 }
 
 async function getScreenshots(SnapShotter, config) {
-  return new Promise(async resolve => {
-    if (config.onBeforeSuiteScript)
-      await executeOnBeforeSuiteScript(config.onBeforeSuiteScript);
+  return new Promise(async (resolve, reject) => {
+    if (config.onBeforeSuiteScript) {
+      try {
+        await executeOnBeforeSuiteScript(config.onBeforeSuiteScript);
+      } catch (error) {
+        onError();
+        return reject(error);
+      }
+    }
 
     const promises = generateSnapShotPromises(SnapShotter, config);
 

--- a/src/getScreenshots.test.js
+++ b/src/getScreenshots.test.js
@@ -1,7 +1,6 @@
 /* globals expect jest */
 import getScreenshots from './getScreenshots';
 import { executeScript } from './executeScript';
-import logger from './logger';
 
 jest.mock('./executeScript');
 
@@ -98,17 +97,14 @@ describe('gets Screenshots', () => {
     });
   });
 
-  it('logs an error if the On BeforeSuiteScript fails to run', () => {
+  it.only('throws an error if the On BeforeSuiteScript fails to run', () => {
     class MockSnapshotter {
       takeSnap() {
         return jest.fn().mockImplementation(() => Promise.resolve());
       }
     }
-    const executeScriptMock = jest
-      .fn()
-      .mockImplementation(() => Promise.reject());
-    executeScript.mockImplementation(executeScriptMock);
-    logger.error = jest.fn();
+
+    executeScript.mockImplementation(() => Promise.reject());
 
     const scenarioCount = 5;
     const config = {
@@ -121,8 +117,6 @@ describe('gets Screenshots', () => {
       onBeforeSuiteScript: './src/__mocks__/onBeforeSuiteMock.js'
     };
 
-    return getScreenshots(MockSnapshotter, config).then(() => {
-      return expect(logger.error).toHaveBeenCalled();
-    });
+    return expect(getScreenshots(MockSnapshotter, config)).rejects.toThrow();
   });
 });

--- a/src/getScreenshots.test.js
+++ b/src/getScreenshots.test.js
@@ -76,10 +76,8 @@ describe('gets Screenshots', () => {
         return jest.fn().mockImplementation(() => Promise.resolve());
       }
     }
-    const executeScriptMock = jest
-      .fn()
-      .mockImplementation(() => Promise.resolve());
-    executeScript.mockImplementation(executeScriptMock);
+
+    executeScript.mockImplementation(() => Promise.resolve());
 
     const scenarioCount = 5;
     const config = {
@@ -93,11 +91,14 @@ describe('gets Screenshots', () => {
     };
 
     return getScreenshots(MockSnapshotter, config).then(() => {
-      return expect(executeScriptMock).toHaveBeenCalledTimes(1);
+      expect(executeScript).toHaveBeenCalledTimes(1);
+      expect(executeScript).toHaveBeenCalledWith(
+        './src/__mocks__/onBeforeSuiteMock.js'
+      );
     });
   });
 
-  it.only('throws an error if the On BeforeSuiteScript fails to run', () => {
+  it('throws an error if the On BeforeSuiteScript fails to run', () => {
     class MockSnapshotter {
       takeSnap() {
         return jest.fn().mockImplementation(() => Promise.resolve());

--- a/src/snapshotter.js
+++ b/src/snapshotter.js
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import jimp from 'jimp';
 import logger from './logger';
-import executeScript from './executeScript';
+import { executeScriptWithDriver } from './executeScript';
 
 export default class SnapShotter {
   constructor(
@@ -202,7 +202,7 @@ export default class SnapShotter {
         });
 
       if (this._onBeforeScript)
-        await executeScript(this._driver, this._onBeforeScript).catch(
+        await executeScriptWithDriver(this._driver, this._onBeforeScript).catch(
           this.handleScriptError
         );
 
@@ -211,7 +211,7 @@ export default class SnapShotter {
       if (this._waitForElement) await this.waitForElement();
 
       if (this._onReadyScript)
-        await executeScript(this._driver, this._onReadyScript).catch(
+        await executeScriptWithDriver(this._driver, this._onReadyScript).catch(
           this.handleScriptError
         );
 

--- a/src/snapshotter.test.js
+++ b/src/snapshotter.test.js
@@ -234,8 +234,6 @@ describe('The snapshotter', () => {
       onBeforeScript: './src/__mocks__/onReadyScriptMock.js'
     };
 
-    const driver = new webdriver.Builder().build();
-
     const mockSnapshot = new SnapShotter(
       config,
       { webdriver, By, until },
@@ -245,16 +243,13 @@ describe('The snapshotter', () => {
     await mockSnapshot.takeSnap();
 
     expect(executeScriptMock).toBeCalledTimes(1);
-    expect(executeScriptMock).toHaveBeenCalledWith(
-      expect.objectContaining(driver),
-      config.onBeforeScript
-    );
+    expect(executeScriptMock.mock.calls[0][0]).toBeInstanceOf(Object);
+    expect(executeScriptMock.mock.calls[0][1]).toEqual(config.onBeforeScript);
   });
 
   it('Executes the onReady script', async () => {
     const executeScriptMock = jest.fn();
     executeScript.mockImplementation(executeScriptMock);
-    const driver = new webdriver.Builder().build();
 
     const config = {
       gridUrl: 'https://lol.com',
@@ -272,10 +267,8 @@ describe('The snapshotter', () => {
     await mockSnapshot.takeSnap();
 
     expect(executeScriptMock).toBeCalledTimes(1);
-    expect(executeScriptMock).toHaveBeenCalledWith(
-      expect.objectContaining(driver),
-      config.onReadyScript
-    );
+    expect(executeScriptMock.mock.calls[0][0]).toBeInstanceOf(Object);
+    expect(executeScriptMock.mock.calls[0][1]).toEqual(config.onReadyScript);
   });
 
   it('Throws an error if incorrect script file is provided', async () => {

--- a/src/snapshotter.test.js
+++ b/src/snapshotter.test.js
@@ -243,8 +243,10 @@ describe('The snapshotter', () => {
     await mockSnapshot.takeSnap();
 
     expect(executeScriptMock).toBeCalledTimes(1);
-    expect(executeScriptMock.mock.calls[0][0]).toBeInstanceOf(Object);
-    expect(executeScriptMock.mock.calls[0][1]).toEqual(config.onBeforeScript);
+    expect(executeScriptMock).toBeCalledWith(
+      mockSnapshot.driver,
+      config.onBeforeScript
+    );
   });
 
   it('Executes the onReady script', async () => {
@@ -267,8 +269,10 @@ describe('The snapshotter', () => {
     await mockSnapshot.takeSnap();
 
     expect(executeScriptMock).toBeCalledTimes(1);
-    expect(executeScriptMock.mock.calls[0][0]).toBeInstanceOf(Object);
-    expect(executeScriptMock.mock.calls[0][1]).toEqual(config.onReadyScript);
+    expect(executeScriptMock).toBeCalledWith(
+      mockSnapshot.driver,
+      config.onReadyScript
+    );
   });
 
   it('Throws an error if incorrect script file is provided', async () => {

--- a/src/snapshotter.test.js
+++ b/src/snapshotter.test.js
@@ -2,7 +2,7 @@
 import jimp from 'jimp';
 import webdriver, { By, until } from './__mocks__/selenium-webdriver';
 import SnapShotter from './snapshotter';
-import executeScript from './executeScript';
+import { executeScriptWithDriver } from './executeScript';
 import logger from './logger';
 
 jest.mock('fs');
@@ -225,7 +225,7 @@ describe('The snapshotter', () => {
 
   it('Executes the onBefore script', async () => {
     const executeScriptMock = jest.fn();
-    executeScript.mockImplementation(executeScriptMock);
+    executeScriptWithDriver.mockImplementation(executeScriptMock);
 
     const config = {
       gridUrl: 'https://lol.com',
@@ -249,7 +249,7 @@ describe('The snapshotter', () => {
 
   it('Executes the onReady script', async () => {
     const executeScriptMock = jest.fn();
-    executeScript.mockImplementation(executeScriptMock);
+    executeScriptWithDriver.mockImplementation(executeScriptMock);
 
     const config = {
       gridUrl: 'https://lol.com',
@@ -275,7 +275,7 @@ describe('The snapshotter', () => {
     const executeScriptMock = () => {
       throw new Error('file not found');
     };
-    executeScript.mockImplementation(executeScriptMock);
+    executeScriptWithDriver.mockImplementation(executeScriptMock);
     const config = {
       gridUrl: 'https://lol.com',
       url: 'http://cps-render-ci.elb.tnl-dev.ntch.co.uk/',
@@ -330,7 +330,7 @@ describe('The snapshotter', () => {
     const executeScriptMock = () => {
       throw new Error('sad');
     };
-    executeScript.mockImplementation(executeScriptMock);
+    executeScriptWithDriver.mockImplementation(executeScriptMock);
 
     try {
       await new SnapShotter(


### PR DESCRIPTION
Adds an onBeforeSuiteScript config option which runs a script once, before any snaps are taken.

The script is executed without a driver, so all scripts implemented here need to operate independently of the snappshotters' functionality.

executeScript has been extracted from snapshotter into two separate functions; one taking a driver as an argument (for use in snapshotter) and the other without.