### PR TITLE
feat(TNLT-000): add support for non-public S3 buckets

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/src/bin/run.js
+++ b/src/bin/run.js
@@ -52,6 +52,8 @@ program
         ? (config.branch = options.branch)
         : (config.branch = 'default');
 
+      config.remoteBucketAccess = config.remoteBucketAccess || 'public';
+
       validateConfig(config, options.remote);
 
       if (options.run) config.scenarios = filterToScenario(config, options.run);
@@ -87,6 +89,8 @@ program
 
       if (options.browser) config.browser = options.browser;
       config.branch = 'default';
+
+      config.remoteBucketAccess = config.remoteBucketAccess || 'public';
 
       validateConfig(config, options.remote);
 
@@ -124,6 +128,8 @@ program
         : (config.branch = 'default');
 
       config.remote = options.remote;
+      config.remoteBucketAccess = config.remoteBucketAccess || 'public';
+
       validateConfig(config, config.remote);
 
       if (options.run) config.scenarios = filterToScenario(config, options.run);

--- a/src/configValidator.js
+++ b/src/configValidator.js
@@ -9,7 +9,11 @@ const mandatoryLocalFields = [
   'scenarios',
   'browser'
 ];
-const mandatoryRemoteFields = ['remoteBucketName', 'remoteRegion'];
+const mandatoryRemoteFields = [
+  'remoteBucketName',
+  'remoteRegion',
+  'remoteBucketAccess'
+];
 
 function isValid(missingConfigFields) {
   if (missingConfigFields.length > 0) {

--- a/src/configValidator.test.js
+++ b/src/configValidator.test.js
@@ -55,6 +55,7 @@ describe('The Config Validator', () => {
   it('remote config returns true for valid configs', () => {
     const config = {
       remoteBucketName: 'aye-spy',
+      remoteBucketAccess: 'private',
       remoteRegion: 'eu-west-1'
     };
     expect(isRemoteConfigValid(config)).toBe(true);
@@ -83,6 +84,7 @@ describe('The Config Validator', () => {
   it('resolves a correct config', done => {
     const config = {
       remoteBucketName: 'test',
+      remoteBucketAccess: 'public',
       remoteRegion: 'test',
       gridUrl: 'http://selenium.com:4444/wd/hub',
       baseline: './e2eTests/generateHtmlReport/baseline',
@@ -90,12 +92,7 @@ describe('The Config Validator', () => {
       generatedDiffs: './e2eTests/generateHtmlReport/generatedDiffs',
       report: './e2eTests/generateHtmlReport/reports',
       browser: 'chrome',
-      scenarios: [
-        {
-          url: 'http:/google.com/',
-          label: 'homepage'
-        }
-      ]
+      scenarios: [{ url: 'http:/google.com/', label: 'homepage' }]
     };
     validateConfig(config, true).then(done);
   });

--- a/src/remoteActions.js
+++ b/src/remoteActions.js
@@ -18,7 +18,8 @@ const createRemote = config => {
 
   const params = {
     Bucket: config.remoteBucketName,
-    ACL: 'public-read-write',
+    ACL:
+      config.remoteBucketAccess === 'public' ? 'public-read-write' : 'private',
     CreateBucketConfiguration: {
       LocationConstraint: config.remoteRegion
     }
@@ -37,30 +38,32 @@ const createRemote = config => {
 };
 
 const updateRemotePolicy = config => {
-  AWS.config.update({ region: config.remoteRegion });
-  const s3 = new AWS.S3();
-  const Policy = `{
-    "Version": "2008-10-17",
-    "Id": "AyeSpyPolicy",
-    "Statement": [
-        {
-            "Sid": "Stmt1397633323327",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "*"
-            },
-            "Action": "s3:GetObject",
-            "Resource": "arn:aws:s3:::${config.remoteBucketName}/*"
-        }
-    ]
-  }`;
+  if (config.remote && config.remoteBucketAccess === 'public') {
+    AWS.config.update({ region: config.remoteRegion });
+    const s3 = new AWS.S3();
+    const Policy = `{
+      "Version": "2008-10-17",
+      "Id": "AyeSpyPolicy",
+      "Statement": [
+          {
+              "Sid": "Stmt1397633323327",
+              "Effect": "Allow",
+              "Principal": {
+                  "AWS": "*"
+              },
+              "Action": "s3:GetObject",
+              "Resource": "arn:aws:s3:::${config.remoteBucketName}/*"
+          }
+      ]
+    }`;
 
-  const params = {
-    Bucket: config.remoteBucketName,
-    Policy
-  };
+    const params = {
+      Bucket: config.remoteBucketName,
+      Policy
+    };
 
-  s3.putBucketPolicy(params).promise();
+    return s3.putBucketPolicy(params).promise();
+  }
 };
 
 function createDeletionParams(filteredResults, config) {


### PR DESCRIPTION
Currently AyeSpy assumes all S3 buckets must be public. This might not always be the case! As such, this adds support for a new config option `remoteBucketAccess`, which can be `'public'` or `'private'`. It defaults to `'public'`.